### PR TITLE
Add support to properly determine various armor class bonus types

### DIFF
--- a/data-builder/build_affix_groups.py
+++ b/data-builder/build_affix_groups.py
@@ -18,6 +18,8 @@ def build_affix_groups():
     parrying = get_all_saves()
     parrying.append('Armor Class')
 
+    add(groups, 'Enhancement Bonus (Armor)', ['Armor Class'])
+    add(groups, 'Enhancement Bonus (Weapon)', ['Accuracy', 'Damage'])
     add(groups, 'Resistance', get_all_saves())
     add(groups, 'Parrying', parrying)
     add(groups, 'Sheltering', ['Physical Sheltering', 'Magical Sheltering'])

--- a/data-builder/build_synonyms.py
+++ b/data-builder/build_synonyms.py
@@ -11,7 +11,7 @@ def add(data, mainName, synonyms):
 def build_synonyms():
     data = []
 
-    add(data, 'Armor Class', ['AC', 'Natural Armor', 'Protection', 'Shield', 'Armor Bonus'])
+    add(data, 'Armor Class', ['AC', 'Armor Bonus', 'Natural Armor', 'Natural Armor Bonus', 'Protection', 'Rough Hide', 'Shield'])
     add(data, 'Armor-Piercing', ['Fortification Bypass'])
     add(data, 'False Life', ['Hit Points', 'Vitality', 'Lifeforce', 'Maximum HP'])
     add(data, 'Speed', ['Striding'])

--- a/data-builder/parse_affixes_from_cell.py
+++ b/data-builder/parse_affixes_from_cell.py
@@ -42,7 +42,7 @@ def strip_bonus_types(name):
 def strip_charges(name):
     newName = re.sub(r'(-? \d+ Charges)?( *\(Recharged/[Dd]ay: *?(\d+|None)\))?', '', name)
     return newName.strip() + " clicky" if newName != name else name
-    
+
 
 def strip_necro4_upgrades(name):
     search = re.search(r'^(Upgradeable - [A-Za-z]+ Augment)', name)
@@ -50,7 +50,7 @@ def strip_necro4_upgrades(name):
         return search.group(1)
 
     return name
-    
+
 
 def clean_up_old_augments(name):
     search = re.search(r'^([A-Za-z]+) Slot', name)
@@ -74,7 +74,7 @@ def strip_preslotted_augments(name):
 
 
 def strip_fixed_suffixes(name):
-    for prefix in ["Attuned to Heroism", "Nearly Finished", "Hidden effect (Defiance)", "Visibility 1", 
+    for prefix in ["Attuned to Heroism", "Nearly Finished", "Hidden effect (Defiance)", "Visibility 1",
         "Visibility 2", "Jet Propulsion", "A Mysterious Effect", "Haggle +3 ", "Vampirism 1 ", "Unholy 9 ",
          "Cannith Combat Infusion", "Chitinous Covering", 'Upgradeable Item', 'Thunder-Forged']:
         if name.startswith(prefix):
@@ -121,7 +121,7 @@ def sub_name(name):
         dino_crafting_search = re.search(r'^Isle of Dread: ([A-Za-z]+) Slot (\([A-Za-z]+\))', name)
         if dino_crafting_search:
             return f"{dino_crafting_search.group(1)} {dino_crafting_search.group(2)}"
-        
+
     return name
 
 
@@ -143,7 +143,7 @@ def parse_affixes_from_cell(cell, synonymMap, fakeBonuses, ml):
         affixes = cell.find_all('ul', recursive=False)
         affixes = [ul.find_all('li', recursive=False) for ul in affixes]
         affixes = [item for sublist in affixes for item in sublist]
-    
+
     else:
         affixes = [cell]
 
@@ -174,8 +174,9 @@ def parse_affixes_from_cell(cell, synonymMap, fakeBonuses, ml):
         affixName = cleanup_one_of_the_following(affixName)
         affixName = add_default_one(affixName)
         affixName = x_skills_exceptional_bonus(affixName)
-        
+
         affixName = affixName.strip()
+
 
         affixNameSearch = re.search(r'^(.*?) (- )?\(?\+?(-?[0-9]+)\%?\)?$', affixName)
         if affixNameSearch:
@@ -225,6 +226,9 @@ def parse_affixes_from_cell(cell, synonymMap, fakeBonuses, ml):
                 aff['type'] = bonusTypeSearch[0].strip()
                 if aff['type'] == 'Insightful':
                     aff['type'] = 'Insight'
+                if aff['type'] == 'Natural Armor':
+                    aff['type'] = 'Natural'
+
 
         # Old fortification (heavy/moderate/light) items don't have a type listed, but it's always enhancement
         if aff['name'] == 'Fortification' and aff['value'] in ['25', '75', '100'] and 'type' not in aff:
@@ -282,6 +286,17 @@ def parse_affixes_from_cell(cell, synonymMap, fakeBonuses, ml):
 
         if aff['name'] in synonymMap:
             aff['name'] = synonymMap[aff['name']]
+
+        # unique cases exist where text in description does not correspond to bonus type
+        # need to manually compensate
+        if affix.getText().startswith('Insightful Natural Armor Bonus'):
+            aff['type'] = 'Insight Natural'
+
+        if affix.getText().startswith('Quality Armor Bonus'):
+            aff['type'] = 'Quality'
+
+        if affix.getText().startswith('Rough Hide'):
+            aff['type'] = 'Primal Natural'
 
         ret.append(aff)
 

--- a/data-builder/parse_items.py
+++ b/data-builder/parse_items.py
@@ -116,6 +116,20 @@ def get_items_from_page(itemPageURL, sets):
                 }
                 item['affixes'].append(aff)
 
+        # If we're doing a Shield page, add an entry for the (Shield) Armor Class bonus
+        if 'SB' in cols:
+            acBonus = fields[cols['SB']].getText().strip()
+            if acBonus.startswith('+'):
+                acBonus = acBonus[1:]
+
+            if acBonus != '0' and acBonus.isnumeric():
+                aff = {
+                    'name': 'Armor Class',
+                    'value': acBonus,
+                    'type': 'Shield'
+                }
+                item['affixes'].append(aff)
+
         questsCell = fields[questIdx]
         questsTooltipSpan = questsCell.find('a')
         questsTooltip = questsTooltipSpan.get('title') if questsTooltipSpan else None

--- a/data-builder/parse_items.py
+++ b/data-builder/parse_items.py
@@ -181,26 +181,24 @@ def get_items_from_page(itemPageURL, sets):
                 if item['slot'] == 'Armor':
                     isArmor = True
 
+                # identify shield items based on item type
                 if ((item['type'] == 'Bucklers') or \
                     (item['type'] == 'Large shields') or \
                     (item['type'] == 'Small shields') or \
                     (item['type'] == 'Tower shields')):
                     isShield = True
 
-                # for armor and shield items - enhancement bonus becomes an enhancement type bonus to armor class
+                # for armor and shield items - enhancement bonus becomes an enhancement type bonus to Enhancement Bonus (Armor)
+                # Enhancement Bonus (Armor) is then bubbled up as enhancement bonus to Armor Class via affix groups
                 if isArmor or isShield:
-                    affix['name'] = 'Armor Class'
+                    affix['name'] = 'Enhancement Bonus (Armor)'
 
                 # assume that every item in your weapon slot that is not a shield and is not an orb is a weapon
-                # for weapon items - enhancement bonus becomes an enhancement type bonus to accuracy and damage
+                # for weapon items - enhancement bonus becomes an enhancement type bonus to Enhancement Bonus (Weapon)
+                # Enhancement Bonus (Weapon is then bubbled up as an enhancement bonus to Accuracy and Damage via affix groups
                 if ((item['slot'] == 'Weapon') or (item['slot'] == 'Offhand')) \
                     and not (isShield or item['type'] == 'Orbs'):
-                    affix['name'] = 'Accuracy'
-                    item['affixes'].append({
-                        'name'  : 'Damage',
-                        'type'  : 'Enhancement',
-                        'value' : affix['value']
-                    })
+                    affix['name'] = 'Enhancement Bonus (Weapon)'
 
         for affix in remove:
             item['affixes'].remove(affix)

--- a/data-builder/parse_items.py
+++ b/data-builder/parse_items.py
@@ -169,15 +169,32 @@ def get_items_from_page(itemPageURL, sets):
                 item['crafting'].append(affix['name'])
                 remove.append(affix)
 
-            # if enhancement bonus found on item we need to translate that enhancement bonus to something else
+            # if enhancement bonus found on item we may need to translate that enhancement bonus to something else
             if affix['name'] == 'Enhancement Bonus':
 
+                # create some booleans to reduce duplication and increase readability
+                isArmor = False
+                isShield = False
+                isWeapon = False
+
+                # assume that all item types that go in to the armor slot are armors
+                if item['slot'] == 'Armor':
+                    isArmor = True
+
+                if ((item['type'] == 'Bucklers') or \
+                    (item['type'] == 'Large shields') or \
+                    (item['type'] == 'Small shields') or \
+                    (item['type'] == 'Tower shields')):
+                    isShield = True
+
                 # for armor and shield items - enhancement bonus becomes an enhancement type bonus to armor class
-                if ((item['slot'] == 'Armor') or (item['slot'] == 'Offhand')):
+                if isArmor or isShield:
                     affix['name'] = 'Armor Class'
 
-                # for weapon items - enhancement bonus becomes enhancement type bonus to accuracy and damage
-                if item['slot'] == 'Weapon':
+                # assume that every item in your weapon slot that is not a shield and is not an orb is a weapon
+                # for weapon items - enhancement bonus becomes an enhancement type bonus to accuracy and damage
+                if ((item['slot'] == 'Weapon') or (item['slot'] == 'Offhand')) \
+                    and not (isShield or item['type'] == 'Orbs'):
                     affix['name'] = 'Accuracy'
                     item['affixes'].append({
                         'name'  : 'Damage',

--- a/data-builder/parse_items.py
+++ b/data-builder/parse_items.py
@@ -169,6 +169,22 @@ def get_items_from_page(itemPageURL, sets):
                 item['crafting'].append(affix['name'])
                 remove.append(affix)
 
+            # if enhancement bonus found on item we need to translate that enhancement bonus to something else
+            if affix['name'] == 'Enhancement Bonus':
+
+                # for armor and shield items - enhancement bonus becomes an enhancement type bonus to armor class
+                if ((item['slot'] == 'Armor') or (item['slot'] == 'Offhand')):
+                    affix['name'] = 'Armor Class'
+
+                # for weapon items - enhancement bonus becomes enhancement type bonus to accuracy and damage
+                if item['slot'] == 'Weapon':
+                    affix['name'] = 'Accuracy'
+                    item['affixes'].append({
+                        'name'  : 'Damage',
+                        'type'  : 'Enhancement',
+                        'value' : affix['value']
+                    })
+
         for affix in remove:
             item['affixes'].remove(affix)
 
@@ -179,7 +195,7 @@ def get_items_from_page(itemPageURL, sets):
 
 def parse_items():
     sets = read_json('sets')
-        
+
     cachePath = "./cache/items/"
     items = []
     for file in os.listdir(cachePath):
@@ -210,7 +226,7 @@ def change_dino_item_affix_name(affix, item):
             affix['name'] = "Claw (Accessory - Artifact)"
         elif affixName == "Horn (Accessory)":
             affix['name'] = "Horn (Accessory - Artifact)"
-    
+
     return affix
 
 def change_lost_purpose_affix_name(affix, item):

--- a/data-builder/parse_set_page.py
+++ b/data-builder/parse_set_page.py
@@ -103,6 +103,10 @@ def string_to_affixes(affixStr, synMap):
         if affix['name'] in synMap:
             affix['name'] = synMap[affix['name']]
 
+        # treat armor class % increase bonus as a uniquely new affix (for now)
+        if ((affix['name'] == 'Armor Class') and ('%' in affixStr)):
+            affix['name'] = affix['name']+' (%)'
+
         affixes.append(affix)
 
     return affixes

--- a/data-builder/parse_set_page.py
+++ b/data-builder/parse_set_page.py
@@ -14,6 +14,7 @@ from get_lost_purpose import get_lost_purpose_sets
 def sub_name(name):
     for pair in [
         ['all Spell DCs', 'Spell DCs'],
+        ['Shield Armor Class', 'Armor Class'],
         ['Spell DC\'s', 'Spell DCs'],
         ['DCs', 'Spell DCs'],
         ['Evocation Spell DCs', 'Evocation Focus'],
@@ -76,6 +77,15 @@ def string_to_affixes(affixStr, synMap):
 
         if affix['name'][-1:] == '.':
             affix['name'] = affix['name'][:-1]
+
+        if ((affix['name'] == 'Natural Armor') and (affix['type'] == 'Artifact')):
+            affix['type'] = 'Artifact Natural'
+
+        if ((affix['name'] == 'Natural Armor') and (affix['type'] == 'Profane')):
+            affix['type'] = 'Profane Natural'
+
+        if ((affix['name'] == 'Shield Armor Class') and (affix['type'] == 'Artifact')):
+            affix['type'] = 'Artifact Shield'
 
         if affix['name'] in synMap:
             affix['name'] = synMap[affix['name']]


### PR DESCRIPTION
Update synonym map to treat Natural Armor Bonus and Rough Hide as Amor Class bonuses
Natural Armor bonus broken out as Natural/Insight Natural/Primal Natural/Artifact Natural/Profane Natural
Fix Quality Armor bonus from not being detected based on effect description
Add support to treat Shield bonus on Shields as Shield bonus to Armor Class
Add support to detect Artifact Shield bonus