### PR TITLE
More synonyms and dread crafting artifact set bonus rework

### DIFF
--- a/data-builder/build_synonyms.py
+++ b/data-builder/build_synonyms.py
@@ -11,15 +11,18 @@ def add(data, mainName, synonyms):
 def build_synonyms():
     data = []
 
-    add(data, 'Accuracy', ['Hit', 'hit'])
+    add(data, 'Accuracy', ['Attack', 'Hit', 'hit'])
     add(data, 'Armor Class', ['AC', 'Armor Bonus', 'Natural Armor', 'Natural Armor Bonus', 'Protection', 'Rough Hide', 'Shield', 'Shield Armor Class'])
     # probably want to standardize on 'Armor Piercing' as the name, but re-work needs to be done on cannith crafting to remove drift
-    add(data, 'Armor-Piercing', ['Armor Piercing', 'Fortification Bypass'])
+    add(data, 'Armor-Piercing', ['Armor Piercing', 'Fortification Bypass', 'Fortification bypass'])
+    add(data, 'Assassinate', ['Assassinate DCs'])
     add(data, 'Damage', ['Damage Bonus', 'Deadly'])
     add(data, 'Devotion', ['Positive Spell Power', 'Positive Spellpower'])
     add(data, 'Evocation Focus', ['Evocation Spell DCs'])
     add(data, 'False Life', ['Hit Points', 'Lifeforce', 'Maximum HP', 'Maximum Hit Points', 'maximum hitpoints', 'Vitality', 'your maximum hit points'])
     add(data, 'Healing Lore', ['Positive Spell Crit Chance', 'Positive Spellcrit Chance'])
+    add(data, 'Seeker', ['Critical Confirmation and Critical Damage'])
+    add(data, 'Deception', ['Sneak Attacks'])
     add(data, 'Speed', ['Striding'])
     add(data, 'Physical Sheltering', ['Physical Resistance Rating', 'PRR'])
     add(data, 'Magical Sheltering', ['Magical Resistance Rating', 'MRR', 'your Magical Resistance Rating'])
@@ -27,7 +30,10 @@ def build_synonyms():
     add(data, 'Sheltering', ['Physical and Magical Resistance Rating'])
     add(data, 'Spell Focus Mastery', ['all Spell DCs', 'all spell DCs', 'DCs', 'Spell DC\'s', 'Spell DCs'])
     add(data, 'Spell Points', ['your maximum Spell Points'])
+    add(data, 'Stunning', ['Stunning DCs'])
+    add(data, 'Sunder', ['Sunder DCs'])
     add(data, 'Tactical Abilities', ['your Tactical Abilities'])
+    add(data, 'Trip', ['Trip DCs'])
     add(data, 'Void Lore', ['Negative Spell Crit Chance'])
     add(data, 'Universal Spell Lore', ['Spell Lore'])
     add(data, 'Universal Spell Power', ['Spellcasting Implement', 'Universal Spellpower'])

--- a/data-builder/parse_cannith.py
+++ b/data-builder/parse_cannith.py
@@ -1,4 +1,4 @@
-import openpyxl 
+import openpyxl
 import json
 from get_most_common_bonus_type import get_most_common_bonus_type
 from write_json import write_json
@@ -7,14 +7,14 @@ import os
 def parse_cannith():
     assumedBonusTypeMap = get_most_common_bonus_type()
 
-    wb = openpyxl.load_workbook(f"{os.path.dirname(__file__)}/cannith-crafting.xlsx") 
-    
+    wb = openpyxl.load_workbook(f"{os.path.dirname(__file__)}/cannith-crafting.xlsx")
+
     for s in range(len(wb.sheetnames)):
         if wb.sheetnames[s] == 'Sheet1':
             break
     wb.active = s
 
-    ws = wb.active 
+    ws = wb.active
 
     itemTypeInfoList = []
 
@@ -49,7 +49,7 @@ def parse_cannith():
         affixes = []
 
         if affix == 'Universal Spell Lore':
-            for lore in ['Acid Lore', 'Cold Lore', 'Electricity Lore', 'Fire Lore', 'Force Lore', 'Light Lore', 'Negative Lore', 'Positive Lore', 'Repair Lore', 'Sonic Lore', 'Spell Lore']:
+            for lore in ['Acid Lore', 'Cold Lore', 'Electricity Lore', 'Fire Lore', 'Force Lore', 'Light Lore', 'Negative Lore', 'Positive Lore', 'Repair Lore', 'Sonic Lore']:
                 affixes.append(lore)
 
         if affix == 'Spell Resistance (Sr)':

--- a/data-builder/parse_dinosaur_bone_crafting.py
+++ b/data-builder/parse_dinosaur_bone_crafting.py
@@ -55,7 +55,7 @@ def get_systems_from_page(soup):
 
             affixes = parse_affixes_from_dino_weapon(affixes)
 
-            add_specific_slot_affixes_to_systems(affixes, system_name, systems, augment_name)
+            add_specific_slot_affixes_to_systems(affixes, system_name, systems, augment_name, fields[1])
 
             option = {}
             option['affixes'] = affixes
@@ -155,10 +155,10 @@ def parse_affixes_from_dino_weapon(affixes):
 
     return returnAffixes
 
-def add_specific_slot_affixes_to_systems(affixes, systemName, systems, augmentName):
+def add_specific_slot_affixes_to_systems(affixes, systemName, systems, augmentName, cell):
     copiedAffixes = affixes[::]
 
-    if systemName == "Scale (Weapon)" and (augmentName == "Brightscale" or augmentName == "Shadowscale" or augmentName == "Iridiscent Scale" or augmentName == "Iridescent Scale"):
+    if systemName == "Scale (Weapon)" and (augmentName == "Brightscale" or augmentName == "Shadowscale" or augmentName == "Iridiscent Scale"):
         copiedAffixes.append(create_affix("Spell Focus Master", "Exceptional", "2"))
 
         systems["Scale " + quarterstaffSystemName]['*'].append({
@@ -171,7 +171,7 @@ def add_specific_slot_affixes_to_systems(affixes, systemName, systems, augmentNa
             'name': augmentName
         })
 
-    if systemName == "Fang (Weapon)" and (augmentName == "Iridiscent Fang" or augmentName == "Iridescent Fang"): # adding the correct spelling here assuming someday someone will correct this on the wiki
+    if ((systemName == "Fang (Weapon)") and (augmentName == "Iridiscent Fang")):
         copiedAffixes.append(create_affix("Spell Lore", "Exceptional", "5"))
 
         systems["Fang " + quarterstaffSystemName]['*'].append({
@@ -184,143 +184,31 @@ def add_specific_slot_affixes_to_systems(affixes, systemName, systems, augmentNa
             'name': augmentName
         })
 
-    if systemName == "Scale (Accessory)":
-        if augmentName == "Scale: False Life":
-            systems["Scale " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("False Life", "Enhancement", "58")],
-                'name': augmentName
-            })
-        elif augmentName == "Scale: Charisma":
-            systems["Scale " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Charisma", "Enhancement", "15")],
-                'name': augmentName
-            })
-        elif augmentName == "Scale: Constitution":
-            systems["Scale " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Constitution", "Enhancement", "15")],
-                'name': augmentName
-            })
-        elif augmentName == "Scale: Dexterity":
-            systems["Scale " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Dexterity", "Enhancement", "15")],
-                'name': augmentName
-            })
-        elif augmentName == "Scale: Intelligence":
-            systems["Scale " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Intelligence", "Enhancement", "15")],
-                'name': augmentName
-            })
-        elif augmentName == "Scale: Strength":
-            systems["Scale " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Strength", "Enhancement", "15")],
-                'name': augmentName
-            })
-        elif augmentName == "Scale: Wisdom":
-            systems["Scale " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Wisdom", "Enhancement", "15")],
-                'name': augmentName
-            })
-        else:
-            systems["Scale " + artifactSystemName]['*'].append({
-                'affixes': copiedAffixes,
-                'name': augmentName
-            })
+    # case exists for some systems to add in the artifact version of the slot
+    if systemName in ['Claw (Accessory)', 'Fang (Accessory)', 'Horn (Accessory)', 'Scale (Accessory)']:
+        slotName = systemName.replace('(Accessory)', artifactSystemName)
 
-    if systemName == "Fang (Accessory)":
-        if augmentName == "Fang: Healing Amplification":
-            systems["Fang " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Healing Amplification", "Competence", "61")],
-                'name': augmentName
-            })
-        elif augmentName == "Fang: Negative Amplification":
-            systems["Fang " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Negative Amplification", "Profane", "61")],
-                'name': augmentName
-            })
-        elif augmentName == "Fang: Repair Amplification":
-            systems["Fang " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Negative Amplification", "Enhancement", "61")],
-                'name': augmentName
-            })
-        elif augmentName == "Fang: Accuracy":
-            systems["Fang " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Accuracy", "Competence", "23")],
-                'name': augmentName
-            })
-        elif augmentName == "Fang: Damage":
-            systems["Fang " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Damage", "Competence", "12")],
-                'name': augmentName
-            })
-        elif augmentName == "Fang: Deception":
-            systems["Fang " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Deception", "Enhancement", "12")],
-                'name': augmentName
-            })
-        elif augmentName == "Fang: Seeker":
-            systems["Fang " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Seeker", "Enhancement", "15")],
-                'name': augmentName
-            })
+        artifactValueSearch = re.search(r'^.*? into a Minor Artifact.*?\+([0-9]+).*?(?:\+[0-9]+)?.*$', cell.getText())
+        if artifactValueSearch:
+            artifactAffixMap = {
+                'affixes' : [
+                    {
+                        'description' : None,
+                        'name' : affixes[0]['name'],
+                        'type' : affixes[0]['type'],
+                        'value' : artifactValueSearch.group(1).strip(),
+                    },
+                ],
+            }
         else:
-            systems["Fang " + artifactSystemName]['*'].append({
+            artifactAffixMap = {
                 'affixes': copiedAffixes,
-                'name': augmentName
-            })
+            }
 
-    if systemName == "Claw (Accessory)":
-        if augmentName == "Claw: Physical Resistance Rating":
-            systems["Claw " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Physical Resistance Rating", "Enhancement", "38")],
-                'name': augmentName
-            })
-        elif augmentName == "Claw: Magical Resistance Rating":
-            systems["Claw " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Magical Resistance Rating", "Enhancement", "38")],
-                'name': augmentName
-            })
-        elif augmentName == "Claw: Stunning":
-            systems["Claw " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Stunning", "Enhancement", "17")],
-                'name': augmentName
-            })
-        elif augmentName == "Claw: Trip":
-            systems["Claw " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Trip", "Enhancement", "17")],
-                'name': augmentName
-            })
-        elif augmentName == "Claw: Sunder":
-            systems["Claw " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Sunder", "Enhancement", "17")],
-                'name': augmentName
-            })
-        elif augmentName == "Claw: Assassinate":
-            systems["Claw " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Assassinate", "Enhancement", "17")],
-                'name': augmentName
-            })
-        elif augmentName == "Claw: Spell Penetration":
-            systems["Claw " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Spell Penetration", "Enhancement", "10")],
-                'name': augmentName
-            })
-        else:
-            systems["Claw " + artifactSystemName]['*'].append({
-                'affixes': copiedAffixes,
-                'name': augmentName
-            })
+        artifactAffixMap['name'] = augmentName
+        # artifactAffixMap['name'] = 'name' : '%s +%s %s' % (copiedAffixes[0]['name'], copiedAffixes[0]['value'], copiedAffixes[0]['type'])
 
-    if systemName == "Horn (Accessory)":
-        if augmentName == "Horn: Armor Piercing":
-            systems["Horn " + artifactSystemName]['*'].append({
-                'affixes': [create_affix("Armor Piercing", "Enhancement", "23")],
-                'name': augmentName
-            })
-        else:
-            systems["Horn " + artifactSystemName]['*'].append({
-                'affixes': copiedAffixes,
-                'name': augmentName
-            })
+        systems[slotName]['*'].append(artifactAffixMap)
 
 def create_affix(name, type, value):
     affix = {


### PR DESCRIPTION
* Add various synonyms to consolidate affixes
* Clean up extra code to compensate for misspelled words (Iridescent) in wiki
* Add support in dinosaur bone crafting parse functions to calculate bonuses from cell data instead of hard coding values
* Rework code to generate artifact crafting sets dynamically instead of statically
* Prepare for updating dinosaur crafting augment names to provide more information about bonus instead of just being named based off of the augment (Charisma +2 Exceptional vs Sparkclaw)




