### PR TITLE
Add support for newer raid item properties (crafting enchantments)

### DIFF
--- a/data-builder/build_crafting.py
+++ b/data-builder/build_crafting.py
@@ -4,6 +4,8 @@ from parse_slavers import parse_slavers_crafting
 from parse_augments import parse_augments
 from write_json import write_json
 from get_lost_purpose import get_lost_purpose_crafting
+from get_item_crafting import get_item_crafting
+
 import os
 
 def build_crafting():
@@ -16,11 +18,14 @@ def build_crafting():
 
     augments = parse_augments()
 
+    item_crafting = get_item_crafting()
+
     combined = {}
     combined.update(nearlyFinished)
     combined.update(slavers)
     combined.update(augments)
     combined.update(lost_purpose)
+    combined.update(item_crafting)
 
     # loop through all Crafting map entries to identify effect names that need to be transformed
     for CraftingSystemName, CraftingSystemMap in combined.items():

--- a/data-builder/download_wiki_pages.py
+++ b/data-builder/download_wiki_pages.py
@@ -87,7 +87,7 @@ def download_crafting_pages():
     if not os.path.exists(cacheDir):
         os.makedirs(cacheDir)
 
-    download_page('Dinosaur_Bone_crafting', cacheDir)
+    download_page('Raw data/Item crafting enchantments', cacheDir)
 
 
 def download_wiki_pages():

--- a/data-builder/get_item_crafting.py
+++ b/data-builder/get_item_crafting.py
@@ -1,0 +1,52 @@
+from bs4 import BeautifulSoup
+from get_inverted_synonym_map import get_inverted_synonym_map
+from parse_affixes_from_cell import parse_affixes_from_cell
+from pprint import pprint
+
+
+def get_systems_from_page(soup):
+    synonymMap = get_inverted_synonym_map()
+
+    tables = soup.find(id='bodyContent').find(id='mw-content-text').find_all('table', class_="wikitable")
+
+    systems = {}
+
+    for table in tables:
+        headers = table.find_all('th')
+
+        body = table.find('tbody')
+
+        rows = body.find_all('tr', recursive=False)
+
+        for row in rows[1:]:
+            fields = row.find_all('td', recursive=False)
+
+            system_name = fields[0].find_all('a')[0].getText()
+
+            systems[system_name] = {}
+            systems[system_name]['*'] = []
+
+            affix_selection = parse_affixes_from_cell('', fields[1], synonymMap, {}, None, {}, {})
+
+            for affix_option in affix_selection:
+                option = {}
+                option['affixes'] = []
+                option['affixes'].append(affix_option)
+                systems[system_name]['*'].append(option)
+
+    return systems
+
+
+def get_item_crafting():
+    page = open('./cache/crafting/Raw data_Item crafting enchantments.html', "r", encoding='utf-8').read()
+
+    soup = BeautifulSoup(page, 'html.parser')
+
+    systems = get_systems_from_page(soup)
+
+    return systems
+
+
+if __name__ == "__main__":
+    system = get_item_crafting()
+    pprint(system)


### PR DESCRIPTION
* Remove dinosaur bone crafting page download (deprecated by item augment refactor)
* Add support for Raw data/Item crafting enchantments download
	this allows for a single wiki page to outline which enhancements can be upgraded through crafting

(Currently Sealed in Gloom, Sealed in Mist, and Sealed in Undeath, but this can expand easily moving forward. May even be able to retrofit some other crafting related customizable item properties.)