### PR TITLE
Update various effect calculations related to augment data in the wiki (also has beneficial side effects)

### DIFF
--- a/data-builder/build_synonyms.py
+++ b/data-builder/build_synonyms.py
@@ -12,6 +12,7 @@ def build_synonyms():
     data = []
 
     add(data, 'Accuracy', ['Attack', 'Hit', 'hit', 'Attack Bonus'])
+    add(data, 'Action Boost Charges', ['Action Boost Enhancement'])
     add(data, 'Armor Class', ['AC', 'Armor Bonus', 'Natural Armor', 'Natural Armor Bonus', 'Protection', 'Rough Hide', 'Shield', 'Shield Armor Class'])
     # probably want to standardize on 'Armor Piercing' as the name, but re-work needs to be done on cannith crafting to remove drift
     add(data, 'Armor-Piercing', ['Armor Piercing', 'Fortification Bypass', 'Fortification bypass'])
@@ -42,7 +43,7 @@ def build_synonyms():
     add(data, 'Healing Amplification', ['Positive Healing Amplification', 'Positive Amplification'])
     add(data, 'Negative Amplification', ['Negative Healing Amplification'])
     add(data, 'Repair Amplification', ['Repair Healing Amplification'])
-    add(data, 'Well Rounded', ['All Ability Scores', 'all Ability Scores', 'all of your Ability Scores', 'Well-Rounded', 'Ability stats'])
+    add(data, 'Well Rounded', ['Ability stats', 'All Ability Scores', 'all Ability Scores', 'all of your Ability Scores', 'each Ability Score', 'Well-Rounded'])
     add(data, 'Sundering', ['Sunder', 'Sunder DC'])
     add(data, 'Vertigo', ['Trip', 'Trip DC'])
     add(data, 'Silver', ['Silver , Alchemical'])

--- a/data-builder/parse_affixes_from_cell.py
+++ b/data-builder/parse_affixes_from_cell.py
@@ -32,7 +32,7 @@ def convert_roman_numerals(name):
 
 
 def strip_bonus_types(name):
-    for type in [ 'Artifact', 'Competence', 'Enhanced', 'Equipment', 'Equipped', 'Exceptional', 'Festive', 'Inherent', 'Insightful', 'Profane', 'Quality', 'Sacred']:
+    for type in [ 'Artifact', 'Competence', 'Enhanced', 'Enhancement', 'Equipment', 'Equipped', 'Exceptional', 'Festive', 'Inherent', 'Insightful', 'Profane', 'Quality', 'Sacred']:
         if name.startswith(type):
             name = name[len(type)+1:]
 
@@ -268,6 +268,11 @@ def translate_list_tag_to_affix_map(itemName, tag, synonymMap, fakeBonuses, ml, 
         aff['type'] = affixNameSearch.group(3)
         aff['value'] = affixNameSearch.group(2)
 
+    # ex: Action Boost Enhancement
+    affixNameSearch = re.search(r'^.*(Action Boost Enhancement).*$', affixName)
+    if ((affixNameSearch) and ('name' not in aff)):
+        aff['name'] = affixNameSearch.group(1)
+
     # if previous pass did not populate a name, then just put the full value of the enchantment name as the affix name
     if 'name' not in aff:
         aff['name'] = affixName.strip()
@@ -306,6 +311,12 @@ def translate_list_tag_to_affix_map(itemName, tag, synonymMap, fakeBonuses, ml, 
     if ((tooltipSearch) and ('value' not in aff)):
         aff['value'] = tooltipSearch.group(1)
 
+    # ex: ... will increase the total number of Action Boosts you can use by 3. ...
+    tooltipSearch = re.search(r'^.*?you can use by ([0-9]+).*$', words)
+    if ((tooltipSearch) and ('value' not in aff)):
+        aff['value'] = tooltipSearch.group(1)
+        if ('type' not in aff):
+            aff['type'] = 'Enhancement'
 
     # begin logic for name and type translations
 


### PR DESCRIPTION
    Add support for proper calculation of Action Boost Charges
    Treat generic enhancements of "each Ability Score" as Well Rounded
    Remove extraneous "Enhancement" prefix on various augment effects
    Also has a side effect of preparing for future parsing of "you can use by" effects (like turning and dragonmarks)